### PR TITLE
支持多自定义弹幕源、优化相似合并算法及 UI 细节修复

### DIFF
--- a/ede.js
+++ b/ede.js
@@ -2304,6 +2304,18 @@
             lsSetItem(lsKeys.typeFilter.id, typeFilterTemp);
             msg += `\n已自动添加 ${lsKeys.typeFilter.name}:${danmakuTypeFilterOpts.bottom.name}`;
         }
+        // 弹幕数量上来后合并弹幕真的很卡
+       // const mergeSimilarEnable = lsGetItem(lsKeys.mergeSimilarEnable.id);
+       // if (!mergeSimilarEnable) {
+       //     window.ede.tempLsValues[lsKeys.mergeSimilarEnable.id] = mergeSimilarEnable;
+       //     lsSetItem(lsKeys.mergeSimilarEnable.id, true);
+       //     msg += `\n已自动调整 ${lsKeys.mergeSimilarEnable.name}:true`;
+      //  }
+      //  if (msg.length != initMsgLenth) {
+      //      embyToast({ text: msg });
+       //     console.log('[自动过滤] ' + msg);
+      //  }
+
     }
 
     function danmakuAutoFilterCancel() {


### PR DESCRIPTION
我也不太清楚PR流程，目前使用了AI修改并总结了下修改部分，具体还需要麻烦审查一下。
感觉有问题的地方就在于这两个地方
will-change: transform, opacity好像只对dom有效
const mergeSimilarEnable = lsGetItem(lsKeys.mergeSimilarEnable.id);这部分弹幕数量多会自动开启合并相似弹幕，但基本也合并不了多少弹幕，所以注释掉了。并且在使用windows客户端合并5W的弹幕的情况下哪怕把算法改了下也会卡几秒，原本的算法卡顿时间更长
目前自用未碰见什么问题

1. ✨ 新增：支持多个自定义弹幕源
修改了 searchEpisodes 逻辑，现在支持配置多个自定义 API 源。

在 lsKeys 中新增了 customApiList 配置项，替代原有的单一 customApiPrefix（兼容旧逻辑），允许用户定义多个第三方源并按顺序尝试匹配。

2. ⚡️ 性能优化：重构相似弹幕合并算法
针对弹幕数量较多时页面卡顿的问题，对 danmakuMergeSimilar 和 similarityPercentage 函数进行了深度优化：

算法优化：使用 Int32Array 代替普通数组进行 Levenshtein 距离计算，减少内存开销。

预判剪枝：在进行昂贵的字符串相似度计算前，增加长度差异预判。如果两个弹幕长度差异过大（导致理论最大相似度低于阈值），直接跳过计算。

查找优化：移除原本 O(n) 的数组 includes 查找，改为在对象上直接标记 _is_merged_temp，大幅提升循环效率。

CSS 优化：给弹幕容器添加了 will-change: transform, opacity 属性，提示浏览器进行 GPU 渲染优化。

3. 🐛 修复与体验改进 (UI/UX)
按钮状态修复：修复了初始化时，弹幕开关按钮图标可能与实际开启状态不一致的问题（initUI 中添加了状态检查逻辑）。

界面显示：

调整了默认参数：显示区域改为 70%，透明度 100%，速度 100

修复了“手动匹配”界面中，自动匹配成功后不更新“弹弹 play 总量”显示的问题。