### PR TITLE
fix custom API manual search parsing

### DIFF
--- a/ede.js
+++ b/ede.js
@@ -1283,11 +1283,17 @@
         return await ApiClient.getItem(ApiClient.getCurrentUserId(), id);
     }
 
-    async function fetchSearchEpisodes(anime, episode, prefix) {
+    async function fetchSearchEpisodes(anime, episode, prefix, searchOptions = {}) {
         if (!anime) { throw new Error('anime is required'); }
 
         // 步骤1: 使用 /api/v2/search/anime 搜索动画
-        const searchUrl = `${prefix}/search/anime?keyword=${encodeURIComponent(anime)}`;
+        let searchUrl = `${prefix}/search/anime?keyword=${encodeURIComponent(anime)}`;
+        if (searchOptions.season !== null && searchOptions.season !== undefined) {
+            searchUrl += `&season=${encodeURIComponent(searchOptions.season)}`;
+        }
+        if (searchOptions.episode !== null && searchOptions.episode !== undefined) {
+            searchUrl += `&episode=${encodeURIComponent(searchOptions.episode)}`;
+        }
         const searchResult = await fetchJson(searchUrl)
             .catch((error) => {
                 logger.error(`[API请求] /search/anime 查询失败: ${error.message}`);
@@ -7778,19 +7784,28 @@
             if (!config?.enabled || !config?.prefix) return [];
 
             let manualSearchTitle = searchName;
+            let manualSearchSeason = null;
             let manualSearchEpisode = null;
 
-            if (apiKey === 'official') {
-                const parsed = parseAnimeName(searchName);
-                if (parsed.season !== null) {
+            const parsed = parseAnimeName(searchName);
+            if (parsed.season !== null) {
+                manualSearchSeason = parsed.season;
+                manualSearchEpisode = parsed.episode;
+
+                if (apiKey === 'official') {
                     manualSearchTitle = parsed.season === 1 ? parsed.title : `${parsed.title} 第${parsed.season}季`;
-                    manualSearchEpisode = parsed.episode;
                     logger.info(`[手动匹配][弹弹play优化] 格式化搜索: 标题='${manualSearchTitle}', 集数=${manualSearchEpisode}`);
+                } else {
+                    manualSearchTitle = parsed.title;
+                    logger.info(`[手动匹配][自定义API优化] 格式化搜索: 标题='${manualSearchTitle}', 季数=${manualSearchSeason}, 集数=${manualSearchEpisode}`);
                 }
             }
 
             try {
-                const animaInfo = await fetchSearchEpisodes(manualSearchTitle, manualSearchEpisode, config.prefix);
+                const customSearchOptions = apiKey === 'official'
+                    ? {}
+                    : { season: manualSearchSeason, episode: manualSearchEpisode };
+                const animaInfo = await fetchSearchEpisodes(manualSearchTitle, manualSearchEpisode, config.prefix, customSearchOptions);
                 if (animaInfo && animaInfo.animes.length > 0) {
                     // [黑名单] 对搜索结果应用黑名单过滤
                     animaInfo.animes = applySearchBlacklist(animaInfo.animes, true, apiKey);


### PR DESCRIPTION
## What changed

- Parse `SxxExx` manual-search input for custom API sources as well as the official source.
- Send custom APIs a clean title plus separate `season` and `episode` query parameters.
- Preserve the existing official DandanPlay title formatting behavior.

## Why

The manual-search input can be prefilled with a filename-like value such as `武林外传 S01E02`. The client previously parsed that value only for the official API. Custom APIs therefore received the entire string as the `/search/anime` keyword, while compatible servers such as `danmu_api` expect a clean keyword and optional `season`/`episode` parameters.

Automatic matching did not have the same problem because `/match` parses `fileName` server-side.

## Impact

Custom API manual searches now generate requests such as:

```text
/search/anime?keyword=武林外传&season=1&episode=2
```

Plain-title searches and official API searches keep their existing behavior.

## Checks

- `node --check ede.js`
- `git diff --check`
- Verified request construction for plain titles, `S01E02`, and `S02E03` inputs.
